### PR TITLE
Add `class` and `target` args to `icon_link()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: distilltools
 Type: Package
 Title: A collection of tools to assist in the creating and styling of content on {distill} websites
-Version: 0.0.0.9002
+Version: 0.0.0.9003
 Authors@R: c(
   person("Ella", "Kaye", email = "E.Kaye.1@warwick.ac.uk", role = c("aut", "cre")),
   person("John Paul", "Helveston", role = c("aut")),
@@ -16,7 +16,7 @@ Encoding: UTF-8
 LazyData: true
 BugReports: https://github.com/EllaKaye/distilltools/issues
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Imports: 
     distill,
     htmltools,

--- a/R/icons.R
+++ b/R/icons.R
@@ -78,19 +78,31 @@ make_icon_text <- function(icon, text, style = "default") {
 #' There are three short icon names that appear in both font awesome and academicons. They are "mendeley", "orcid" and "researchgate". These functions default to the font awesome versions (since font awesome should work out-the-box with `distill` whereas academicons needs the stylesheet adding - see above), but the academicon versions can be accessed by using their full name, e.g. `"ai ai-orcid"`. Note that in early testing the font awesome icons for "orcid" and "mendeley" were troublesome for one of the authors, but the academicon versions worked fine.
 #'
 #' @param icon The name of the icon. For Font Awesome icons, the name should correspond to the current Version 5 name and can either be the the short name (e.g. `"github"`) or the full name (e.g. `"fab fa-github"`). [Academicons](https://jpswalsh.github.io/academicons/) can also be used and styled the same way (e.g. `"google-scholar"` or `"ai ai-google-scholar"`) but require a site header. See [here](https://www.jhelvy.com/posts/2021-03-25-customizing-distill-with-htmltools-and-css/#side-note-on-academic-icons) for details.
-#' @param text A string of the text to appear on the button
-#' @param url A url for where the button should link to
+#' @param text A string of the text to appear on the button.
+#' @param url A url for where the button should link to.
 #' @param style The style of the font awesome icon, which can be "default", "solid" or "regular". This parameter is only used when the short name of the icon is used in the `icon` argument and there is more than one style available for that icon. In that case, the default becomes "solid".
+#' @param class A string to define a class, defaults to "icon-link".
+#' @param target A string to define a target, typically `"_blank"`, `"_self"`,
+#' `"_parent"`, or `"_top"`. Defaults to "_blank".
 #' @return For `make_icon`, a `shiny.tag` with the HTML `<i class = "icon"></i>`. For `icon_link`, a `shiny.tag` with the HTML `<a href=url class="icon-link" target = "_blank" rel = "noopener"><i class=icon></i> text</a>`
 #' @author John Paul Helveston and Ella Kaye
 #' @examples icon_link("github", "materials", "https://github.com/USER/REPO")
 #' @examples icon_link("images", "slides", "https://USER.github.io/slides", style = "regular")
 #' @export
-icon_link <- function(icon = NULL, text = NULL, url = NULL, style = "default") {
+icon_link <- function(
+  icon = NULL,
+  text = NULL,
+  url = NULL,
+  style = "default",
+  class = "icon-link",
+  target = "_blank"
+) {
   if (!is.null(icon)) {
     text <- make_icon_text(icon, text, style = style)
   }
-  return(htmltools::a(href = url, text, class = "icon-link", target = "_blank", rel = "noopener"))
+  return(htmltools::a(
+    href = url, text, class = class, target = target, rel = "noopener"
+  ))
 }
 
 # icons that appear in fontawesome academicons

--- a/man/icon_link.Rd
+++ b/man/icon_link.Rd
@@ -7,16 +7,28 @@
 \usage{
 make_icon(icon, style = "default")
 
-icon_link(icon = NULL, text = NULL, url = NULL, style = "default")
+icon_link(
+  icon = NULL,
+  text = NULL,
+  url = NULL,
+  style = "default",
+  class = "icon-link",
+  target = "_blank"
+)
 }
 \arguments{
 \item{icon}{The name of the icon. For Font Awesome icons, the name should correspond to the current Version 5 name and can either be the the short name (e.g. \code{"github"}) or the full name (e.g. \code{"fab fa-github"}). \href{https://jpswalsh.github.io/academicons/}{Academicons} can also be used and styled the same way (e.g. \code{"google-scholar"} or \code{"ai ai-google-scholar"}) but require a site header. See \href{https://www.jhelvy.com/posts/2021-03-25-customizing-distill-with-htmltools-and-css/#side-note-on-academic-icons}{here} for details.}
 
 \item{style}{The style of the font awesome icon, which can be "default", "solid" or "regular". This parameter is only used when the short name of the icon is used in the \code{icon} argument and there is more than one style available for that icon. In that case, the default becomes "solid".}
 
-\item{text}{A string of the text to appear on the button}
+\item{text}{A string of the text to appear on the button.}
 
-\item{url}{A url for where the button should link to}
+\item{url}{A url for where the button should link to.}
+
+\item{class}{A string to define a class, defaults to "icon-link".}
+
+\item{target}{A string to define a target, typically \code{"_blank"}, \code{"_self"},
+\code{"_parent"}, or \code{"_top"}. Defaults to "_blank".}
 }
 \value{
 For \code{make_icon}, a \code{shiny.tag} with the HTML \verb{<i class = "icon"></i>}. For \code{icon_link}, a \code{shiny.tag} with the HTML \verb{<a href=url class="icon-link" target = "_blank" rel = "noopener"><i class=icon></i> text</a>}

--- a/man/modify_default_highlighting.Rd
+++ b/man/modify_default_highlighting.Rd
@@ -42,7 +42,7 @@ Distill site or blog:
 \enumerate{
 \item Apply it site-wide by adding a \code{theme} key to the top-level of your
 \verb{_site.yml} configuration file (assuming the theme file is in your
-root directory):\if{html}{\out{<div class="yaml">}}\preformatted{output:
+root directory):\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{output:
   distill::distill_article:
     highlight: highlighting.theme
 }\if{html}{\out{</div>}}
@@ -54,7 +54,7 @@ writing. There is an open
 \enumerate{
 \item Apply to an individual article by adding a \code{theme} key to your
 article’s YAML front-matter, using the full path (assuming that the
-\code{.theme} file is in the site root directory), e.g.:\if{html}{\out{<div class="yaml">}}\preformatted{---
+\code{.theme} file is in the site root directory), e.g.:\if{html}{\out{<div class="sourceCode yaml">}}\preformatted{---
 title: "My Highlighting Theme"
 output:
   distill::distill_article:


### PR DESCRIPTION
I wanted to be able to create different classes for different types of link buttons, so I just moved these to the arguments, keeping the current values as defaults. Just gives the user the option to further customize.

As an example, I've used this on my [research page](https://www.jhelvy.com/research) where I have a different button class for the "details" button compared to the other buttons.